### PR TITLE
Fixed calendar dropdown refresh issue after retrieving new calendar

### DIFF
--- a/Marble/Core/Settings.cs
+++ b/Marble/Core/Settings.cs
@@ -1,12 +1,4 @@
-﻿/*
- * Created by SharpDevelop.
- * User: smithjay
- * Date: 12/31/2014
- * Time: 8:52 AM
- * 
- * To change this template use Tools | Options | Coding | Edit Standard Headers.
- */
-using System;
+﻿using System;
 using System.Reflection;
 
 namespace Marble
@@ -137,6 +129,7 @@ namespace Marble
 		public static void Save()
 		{
 			Properties.Settings.Default.Save();
+            Properties.Settings.Default.Reload();
 		}
 		
 		public static string Description
@@ -186,6 +179,21 @@ namespace Marble
 				return assemblyInfo.Company;
 			}
 		}
+
+        public static DateTime CalendarRangeMinDate
+        {
+            get
+            {
+               return Convert.ToDateTime(DateTime.Now.AddDays(-Settings.CalendarDaysInThePast).ToShortDateString());
+            }
+        }
+        public static DateTime CalendarRangeMaxDate
+        {
+            get
+            {
+                return Convert.ToDateTime(DateTime.Now.AddDays(+Settings.CalendarDaysInTheFuture + 1).ToShortDateString());
+            }
+        }
 		
 	}
 }

--- a/Marble/FormSettings.Designer.cs
+++ b/Marble/FormSettings.Designer.cs
@@ -64,11 +64,11 @@ namespace Marble
             this.checkBoxSyncEveryHour = new System.Windows.Forms.CheckBox();
             this.textBoxMinuteOffset = new System.Windows.Forms.TextBox();
             this.buttonGetCalendars = new System.Windows.Forms.Button();
+            this.comboBoxCalendars = new System.Windows.Forms.ComboBox();
             this.labelCalendar = new System.Windows.Forms.Label();
             this.buttonOk = new System.Windows.Forms.Button();
             this.groupBoxOptions = new System.Windows.Forms.GroupBox();
             this.checkBoxStartWithWindows = new System.Windows.Forms.CheckBox();
-            this.comboBoxCalendars = new System.Windows.Forms.ComboBox();
             this.groupBoxGoogleCalendar.SuspendLayout();
             this.groupBoxOptions.SuspendLayout();
             this.SuspendLayout();
@@ -115,9 +115,9 @@ namespace Marble
             // 
             this.buttonClearDataStore.Location = new System.Drawing.Point(374, 29);
             this.buttonClearDataStore.Name = "buttonClearDataStore";
-            this.buttonClearDataStore.Size = new System.Drawing.Size(85, 23);
+            this.buttonClearDataStore.Size = new System.Drawing.Size(101, 23);
             this.buttonClearDataStore.TabIndex = 10;
-            this.buttonClearDataStore.Text = "Clear";
+            this.buttonClearDataStore.Text = "Switch Account";
             this.buttonClearDataStore.UseVisualStyleBackColor = true;
             this.buttonClearDataStore.Click += new System.EventHandler(this.ButtonClearDataStoreClick);
             // 
@@ -179,11 +179,21 @@ namespace Marble
             // 
             this.buttonGetCalendars.Location = new System.Drawing.Point(374, 58);
             this.buttonGetCalendars.Name = "buttonGetCalendars";
-            this.buttonGetCalendars.Size = new System.Drawing.Size(85, 23);
+            this.buttonGetCalendars.Size = new System.Drawing.Size(101, 23);
             this.buttonGetCalendars.TabIndex = 2;
             this.buttonGetCalendars.Text = "Get Calendars";
             this.buttonGetCalendars.UseVisualStyleBackColor = true;
             this.buttonGetCalendars.Click += new System.EventHandler(this.ButtonGetCalendarsClick);
+            // 
+            // comboBoxCalendars
+            // 
+            this.comboBoxCalendars.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxCalendars.FormattingEnabled = true;
+            this.comboBoxCalendars.Location = new System.Drawing.Point(71, 60);
+            this.comboBoxCalendars.Name = "comboBoxCalendars";
+            this.comboBoxCalendars.Size = new System.Drawing.Size(297, 21);
+            this.comboBoxCalendars.TabIndex = 1;
+            this.comboBoxCalendars.SelectedIndexChanged += new System.EventHandler(this.ComboBoxCalendarSelectedIndexChange);
             // 
             // labelCalendar
             // 
@@ -221,16 +231,6 @@ namespace Marble
             this.checkBoxStartWithWindows.TabIndex = 4;
             this.checkBoxStartWithWindows.Text = "Start with Windows";
             this.checkBoxStartWithWindows.UseVisualStyleBackColor = true;
-            // 
-            // comboBoxCalendars
-            // 
-            this.comboBoxCalendars.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxCalendars.FormattingEnabled = true;
-            this.comboBoxCalendars.Location = new System.Drawing.Point(71, 60);
-            this.comboBoxCalendars.Name = "comboBoxCalendars";
-            this.comboBoxCalendars.Size = new System.Drawing.Size(297, 21);
-            this.comboBoxCalendars.TabIndex = 1;
-            this.comboBoxCalendars.SelectedIndexChanged += new System.EventHandler(this.ComboBoxCalendarSelectedIndexChange);
             // 
             // FormSettings
             // 

--- a/Marble/FormSettings.Designer.cs
+++ b/Marble/FormSettings.Designer.cs
@@ -18,8 +18,7 @@ namespace Marble
 		private System.Windows.Forms.GroupBox groupBoxGoogleCalendar;
 		private System.Windows.Forms.Button buttonOk;
 		private System.Windows.Forms.GroupBox groupBoxOptions;
-		private System.Windows.Forms.Button buttonGetCalendars;
-		private System.Windows.Forms.ComboBox comboBoxCalendars;
+        private System.Windows.Forms.Button buttonGetCalendars;
 		private System.Windows.Forms.Label labelCalendar;
 		private System.Windows.Forms.CheckBox checkBoxSyncEveryHour;
 		private System.Windows.Forms.TextBox textBoxMinuteOffset;
@@ -65,11 +64,11 @@ namespace Marble
             this.checkBoxSyncEveryHour = new System.Windows.Forms.CheckBox();
             this.textBoxMinuteOffset = new System.Windows.Forms.TextBox();
             this.buttonGetCalendars = new System.Windows.Forms.Button();
-            this.comboBoxCalendars = new System.Windows.Forms.ComboBox();
             this.labelCalendar = new System.Windows.Forms.Label();
             this.buttonOk = new System.Windows.Forms.Button();
             this.groupBoxOptions = new System.Windows.Forms.GroupBox();
             this.checkBoxStartWithWindows = new System.Windows.Forms.CheckBox();
+            this.comboBoxCalendars = new System.Windows.Forms.ComboBox();
             this.groupBoxGoogleCalendar.SuspendLayout();
             this.groupBoxOptions.SuspendLayout();
             this.SuspendLayout();
@@ -186,15 +185,6 @@ namespace Marble
             this.buttonGetCalendars.UseVisualStyleBackColor = true;
             this.buttonGetCalendars.Click += new System.EventHandler(this.ButtonGetCalendarsClick);
             // 
-            // comboBoxCalendars
-            // 
-            this.comboBoxCalendars.FormattingEnabled = true;
-            this.comboBoxCalendars.Location = new System.Drawing.Point(71, 60);
-            this.comboBoxCalendars.Name = "comboBoxCalendars";
-            this.comboBoxCalendars.Size = new System.Drawing.Size(297, 21);
-            this.comboBoxCalendars.TabIndex = 1;
-            this.comboBoxCalendars.SelectedIndexChanged += new System.EventHandler(this.ComboBoxCalendarSelectedIndexChange);
-            // 
             // labelCalendar
             // 
             this.labelCalendar.Location = new System.Drawing.Point(8, 63);
@@ -232,6 +222,16 @@ namespace Marble
             this.checkBoxStartWithWindows.Text = "Start with Windows";
             this.checkBoxStartWithWindows.UseVisualStyleBackColor = true;
             // 
+            // comboBoxCalendars
+            // 
+            this.comboBoxCalendars.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxCalendars.FormattingEnabled = true;
+            this.comboBoxCalendars.Location = new System.Drawing.Point(71, 60);
+            this.comboBoxCalendars.Name = "comboBoxCalendars";
+            this.comboBoxCalendars.Size = new System.Drawing.Size(297, 21);
+            this.comboBoxCalendars.TabIndex = 1;
+            this.comboBoxCalendars.SelectedIndexChanged += new System.EventHandler(this.ComboBoxCalendarSelectedIndexChange);
+            // 
             // FormSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -254,5 +254,7 @@ namespace Marble
             this.ResumeLayout(false);
 
 		}
+
+        private System.Windows.Forms.ComboBox comboBoxCalendars;
 	}
 }

--- a/Marble/FormSettings.cs
+++ b/Marble/FormSettings.cs
@@ -1,118 +1,109 @@
-﻿/*
- * Created by SharpDevelop.
- * User: smithjay
- * Date: 12/16/2014
- * Time: 8:41 AM
- * 
- * To change this template use Tools | Options | Coding | Edit Standard Headers.
- */
-using System;
+﻿using System;
 using System.Linq;
 using System.Windows.Forms;
-
 using Microsoft.Win32;
-
 using Marble.Google;
 
 namespace Marble
 {
-	/// <summary>
-	/// Description of FormSettings.
-	/// </summary>
-	public partial class FormSettings : Form
-	{
-		readonly GoogleClient googleClient;
-		readonly GoogleCalendarService calendarService;
-		
-		public FormSettings()
-		{
-			InitializeComponent();
-			googleClient = new GoogleClient(Settings.DataStoreFolderNameCalendar);
-			calendarService = new GoogleCalendarService(googleClient);
-		}
-		
-		void FormSettingsLoad(object sender, EventArgs e)
-		{
-			InitializeForm();
-		}
-		
-		void InitializeForm()
-		{
-			GetCalendars();
-			labelSelectedAccountName.Text = Settings.CalendarAccount;
-			comboBoxCalendars.SelectedIndex = comboBoxCalendars.FindStringExact(Settings.CalendarId);
-						
-			checkBoxSyncEveryHour.Checked = Settings.SyncEveryHour;
-			textBoxMinuteOffset.Text = Settings.SyncMinutesOffset.ToString();
-			checkBoxStartWithWindows.Checked = Settings.StartWithWindows;
-			textBoxSyncDaysInPast.Text = Settings.CalendarDaysInThePast.ToString();
-			textBoxSyncDaysInFuture.Text = Settings.CalendarDaysInTheFuture.ToString();
-			
-		}
-		
-		void ButtonGetCalendarsClick(object sender, EventArgs e)
-		{
-			GetCalendars();
-		}
-		
-		void ButtonOkClick(object sender, EventArgs e)
-		{
-			var selectedItem =  (GoogleCalendarInfo) comboBoxCalendars.SelectedItem;
-			
-			Settings.CalendarAccount = selectedItem.Id;
-			Settings.CalendarId = selectedItem.Name;
-			Settings.SyncEveryHour = checkBoxSyncEveryHour.Checked;
-			Settings.SyncMinutesOffset = int.Parse(textBoxMinuteOffset.Text);
-			Settings.StartWithWindows = checkBoxStartWithWindows.Checked;
-			Settings.CalendarDaysInThePast = int.Parse(textBoxSyncDaysInPast.Text);
-			Settings.CalendarDaysInTheFuture = int.Parse(textBoxSyncDaysInFuture.Text);
-			
-			Settings.Save();
-			
-			ConfigureWindowsStartUp();
-			
-			DialogResult = DialogResult.OK;
-			Close();
-		}
-		
-		void ButtonCancelClick(object sender, EventArgs e)
-		{
-			DialogResult = DialogResult.Cancel;
-			Close();
-		}
-		
-		void GetCalendars()
-		{
-			buttonGetCalendars.Enabled = false;
-			comboBoxCalendars.Enabled = false;
-			
-			var calendars = calendarService.GetCalendars();
-			
-			comboBoxCalendars.Items.Clear();
-			foreach (var item in calendars) {
-				comboBoxCalendars.Items.Add(item);
-			}
-			
-			comboBoxCalendars.SelectedIndex = -1;
-			buttonGetCalendars.Enabled = true;
-			comboBoxCalendars.Enabled = true;
-			
-		}
-		
-		void ButtonClearDataStoreClick(object sender, EventArgs e)
-		{
-			googleClient.ClearDataStore();
+    /// <summary>
+    /// Description of FormSettings.
+    /// </summary>
+    public partial class FormSettings : Form
+    {
+        readonly GoogleClient googleClient;
+        readonly GoogleCalendarService calendarService;
+
+        public FormSettings()
+        {
+            InitializeComponent();
+            googleClient = new GoogleClient(Settings.DataStoreFolderNameCalendar);
+            calendarService = new GoogleCalendarService(googleClient);
+        }
+
+        void FormSettingsLoad(object sender, EventArgs e)
+        {
+            InitializeForm();
+        }
+
+        void InitializeForm()
+        {
+            GetCalendars();
+            labelSelectedAccountName.Text = Settings.CalendarAccount;
+            comboBoxCalendars.SelectedIndex = comboBoxCalendars.FindStringExact(Settings.CalendarId);
+
+            checkBoxSyncEveryHour.Checked = Settings.SyncEveryHour;
+            textBoxMinuteOffset.Text = Settings.SyncMinutesOffset.ToString();
+            checkBoxStartWithWindows.Checked = Settings.StartWithWindows;
+            textBoxSyncDaysInPast.Text = Settings.CalendarDaysInThePast.ToString();
+            textBoxSyncDaysInFuture.Text = Settings.CalendarDaysInTheFuture.ToString();
+
+        }
+
+        void ButtonGetCalendarsClick(object sender, EventArgs e)
+        {
+            GetCalendars();
+        }
+
+        void ButtonOkClick(object sender, EventArgs e)
+        {
+            var selectedItem = (GoogleCalendarInfo)comboBoxCalendars.SelectedItem;
+
+            Settings.CalendarAccount = selectedItem.Id;
+            Settings.CalendarId = selectedItem.Name;
+            Settings.SyncEveryHour = checkBoxSyncEveryHour.Checked;
+            Settings.SyncMinutesOffset = int.Parse(textBoxMinuteOffset.Text);
+            Settings.StartWithWindows = checkBoxStartWithWindows.Checked;
+            Settings.CalendarDaysInThePast = int.Parse(textBoxSyncDaysInPast.Text);
+            Settings.CalendarDaysInTheFuture = int.Parse(textBoxSyncDaysInFuture.Text);
+
+            Settings.Save();
+
+            ConfigureWindowsStartUp();
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        void ButtonCancelClick(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+
+        void GetCalendars()
+        {
+            buttonGetCalendars.Enabled = false;
+            comboBoxCalendars.Enabled = false;
+
+            GoogleCalendarService newCalendarService = new GoogleCalendarService(googleClient);
+            var calendars = newCalendarService.GetCalendars();
+
+            comboBoxCalendars.Items.Clear();
+            foreach (var item in calendars)
+            {
+                comboBoxCalendars.Items.Add(item);
+            }
+
+            comboBoxCalendars.SelectedIndex = -1;
+            buttonGetCalendars.Enabled = true;
+            comboBoxCalendars.Enabled = true;
+        }
+
+        void ButtonClearDataStoreClick(object sender, EventArgs e)
+        {
+            googleClient.ClearDataStore();
             comboBoxCalendars.Items.Clear();
             comboBoxCalendars.Text = string.Empty;
             labelSelectedAccountName.Text = string.Empty;
-			Settings.CalendarId = string.Empty;
-			Settings.CalendarAccount = string.Empty;
-			Settings.Save();
-			
-			googleClient.GetAuthorization();
-			
-			InitializeForm();
-		}
+            Settings.CalendarId = string.Empty;
+            Settings.CalendarAccount = string.Empty;
+            Settings.Save();
+
+            googleClient.GetAuthorization();
+
+            InitializeForm();
+        }
 
         void ComboBoxCalendarSelectedIndexChange(object sender, EventArgs e)
         {
@@ -121,22 +112,22 @@ namespace Marble
             Settings.CalendarId = selectedItem.Name;
             labelSelectedAccountName.Text = Settings.CalendarAccount;
         }
-		
-		void ConfigureWindowsStartUp()
-		{
-			const string path = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
-			var key = Registry.CurrentUser.OpenSubKey(path, true);
 
-			if (Settings.StartWithWindows)
-			{
-				// set value in registry
-				if (key != null) key.SetValue(Application.ProductName, Application.ExecutablePath);
-			}
-			else
-			{
-				// remove value from registry
-				if (key != null) key.DeleteValue(Application.ProductName, false);
-			}
-		}
-	}
+        void ConfigureWindowsStartUp()
+        {
+            const string path = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+            var key = Registry.CurrentUser.OpenSubKey(path, true);
+
+            if (Settings.StartWithWindows)
+            {
+                // set value in registry
+                if (key != null) key.SetValue(Application.ProductName, Application.ExecutablePath);
+            }
+            else
+            {
+                // remove value from registry
+                if (key != null) key.DeleteValue(Application.ProductName, false);
+            }
+        }
+    }
 }

--- a/Marble/FormSettings.cs
+++ b/Marble/FormSettings.cs
@@ -11,14 +11,12 @@ namespace Marble
     /// </summary>
     public partial class FormSettings : Form
     {
-        readonly GoogleClient googleClient;
-        readonly GoogleCalendarService calendarService;
+        private GoogleClient googleClient;
+        private GoogleCalendarService calendarService;
 
         public FormSettings()
         {
             InitializeComponent();
-            googleClient = new GoogleClient(Settings.DataStoreFolderNameCalendar);
-            calendarService = new GoogleCalendarService(googleClient);
         }
 
         void FormSettingsLoad(object sender, EventArgs e)
@@ -73,11 +71,13 @@ namespace Marble
 
         void GetCalendars()
         {
+            googleClient = new GoogleClient(Settings.DataStoreFolderNameCalendar);
+            calendarService = new GoogleCalendarService(googleClient);
+            
             buttonGetCalendars.Enabled = false;
             comboBoxCalendars.Enabled = false;
 
-            GoogleCalendarService newCalendarService = new GoogleCalendarService(googleClient);
-            var calendars = newCalendarService.GetCalendars();
+            var calendars = calendarService.GetCalendars();
 
             comboBoxCalendars.Items.Clear();
             foreach (var item in calendars)

--- a/Marble/Google/GoogleCalendarInfo.cs
+++ b/Marble/Google/GoogleCalendarInfo.cs
@@ -1,12 +1,4 @@
-﻿/*
- * Created by SharpDevelop.
- * User: smithjay
- * Date: 12/31/2014
- * Time: 9:18 AM
- * 
- * To change this template use Tools | Options | Coding | Edit Standard Headers.
- */
-using System;
+﻿using System;
 using Google.Apis.Calendar.v3.Data;
 
 
@@ -19,6 +11,12 @@ namespace Marble.Google
 	{
 		public string Id;
 		public string Name;
+
+        public GoogleCalendarInfo(string id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
 		
 		public GoogleCalendarInfo(CalendarListEntry item)
 		{

--- a/Marble/Google/GoogleCalendarService.cs
+++ b/Marble/Google/GoogleCalendarService.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
-
 using Google.Apis.Calendar.v3;
 using Google.Apis.Calendar.v3.Data;
-
 using Marble.Data;
 
 namespace Marble.Google
@@ -22,9 +20,9 @@ namespace Marble.Google
 		
 		public List<GoogleCalendarInfo> GetCalendars()
 		{
-			var calendars = service.CalendarList.List().Execute().Items.Where(x => x.AccessRole == "owner");		
-			
-			var items = new List<GoogleCalendarInfo>();
+			var calendars = service.CalendarList.List().Execute().Items.Where(x => x.AccessRole == "owner");
+
+            var items = new List<GoogleCalendarInfo>();
 			foreach (var calendar in calendars) {
 				items.Add( new GoogleCalendarInfo(calendar));
 			}
@@ -42,8 +40,8 @@ namespace Marble.Google
 			
 			var eventRequest = service.Events.List(Settings.CalendarAccount);
 			
-			eventRequest.TimeMin = DateTime.Now.AddDays(-Settings.CalendarDaysInThePast);
-			eventRequest.TimeMax = DateTime.Now.AddDays(+Settings.CalendarDaysInTheFuture + 1);
+			eventRequest.TimeMin = Settings.CalendarRangeMinDate;
+            eventRequest.TimeMax = Settings.CalendarRangeMaxDate;
 
 			results.AddRange(eventRequest.Execute().Items);
 				

--- a/Marble/Outlook/OutlookCalendarService.cs
+++ b/Marble/Outlook/OutlookCalendarService.cs
@@ -13,8 +13,6 @@ namespace Marble.Outlook
     public class OutlookCalendarService
     {
         public MAPIFolder outlookCalendar;
-        static DateTime min = Convert.ToDateTime(DateTime.Now.AddDays(-Settings.CalendarDaysInThePast).ToShortDateString());
-        static DateTime max = Convert.ToDateTime(DateTime.Now.AddDays(+Settings.CalendarDaysInTheFuture + 1).ToShortDateString());
 
         public OutlookCalendarService()
         {
@@ -44,7 +42,7 @@ namespace Marble.Outlook
 
             if (OutlookItems != null)
             {
-                string filter = "[Start] >= '" + min.ToString("g") + "' AND [End] <= '" + max.ToString("g") + "'";
+                string filter = "[Start] >= '" + Settings.CalendarRangeMinDate.ToString("g") + "' AND [End] <= '" + Settings.CalendarRangeMaxDate.ToString("g") + "'";
                 var filteredAppoinments = OutlookItems.Restrict(filter);
 
                 foreach (_AppointmentItem ai in filteredAppoinments)
@@ -109,9 +107,9 @@ namespace Marble.Outlook
         static void CreateDailyOccurences(List<Appointment> result, _AppointmentItem ai, RecurrencePattern pattern)
         {
             DateTime incrementDate = ai.Start;
-            while (incrementDate <= max && incrementDate <= pattern.PatternEndDate)
+            while (incrementDate <= Settings.CalendarRangeMaxDate && incrementDate <= pattern.PatternEndDate)
             {
-                if (incrementDate >= min)
+                if (incrementDate >= Settings.CalendarRangeMinDate)
                 {
                     result.Add(GetOutlookAppointment(ai, incrementDate));
                 }
@@ -123,8 +121,8 @@ namespace Marble.Outlook
         {
             int interval = pattern.Interval == 0 ? 1 : pattern.Interval;
             int weekCount = interval;
-            DateTime incrementDate = min;
-            while (incrementDate <= max && incrementDate <= pattern.PatternEndDate)
+            DateTime incrementDate = Settings.CalendarRangeMinDate;
+            while (incrementDate <= Settings.CalendarRangeMaxDate && incrementDate <= pattern.PatternEndDate)
             {
                 if (daysOfWeekList.Contains(incrementDate.DayOfWeek) && (weekCount % interval) == 0)
                 {
@@ -138,9 +136,9 @@ namespace Marble.Outlook
         static void CreateMonthlyOccurences(List<Appointment> result, _AppointmentItem ai, RecurrencePattern pattern, List<DayOfWeek> daysOfWeekList)
         {
             DateTime incrementDate = GetIncrementDate(pattern, pattern.PatternStartDate);
-            while (incrementDate <= max)
+            while (incrementDate <= Settings.CalendarRangeMaxDate)
             {
-                if (incrementDate >= min && incrementDate <= pattern.PatternEndDate)
+                if (incrementDate >= Settings.CalendarRangeMinDate && incrementDate <= pattern.PatternEndDate)
                 {
                     result.Add(GetOutlookAppointment(ai, incrementDate));
                 }


### PR DESCRIPTION
In addition, moved the min and max dates to the setting class to create uniformity. 
